### PR TITLE
feat: use command.name string if it exists, else the file name as command name.

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ client.on("error", console.error)
 const commandFiles = readdirSync(join(__dirname, "commands")).filter(file => file.endsWith(".js"))
 for (const file of commandFiles) {
   const command = require(join(__dirname, "commands", `${file}`));
-  client.commands.set(command.name, command)
+  client.commands.set(command.name ? command.name : file, command)
 }
 
 client.on("message", async message => {


### PR DESCRIPTION
Take the work.js command as an example,
```javascript
module.exports = {
    ...
};
```
The name field doesn't exist in the command export object. Thus, the file name will be used and set to the Client#commands collection.