### PR TITLE
Added progressbar and time remaining support to now playing

### DIFF
--- a/commands/nowplaying.js
+++ b/commands/nowplaying.js
@@ -1,3 +1,4 @@
+const createBar = require("string-progressbar");
 const { MessageEmbed } = require("discord.js");
 
 module.exports = {
@@ -7,15 +8,17 @@ module.exports = {
     const queue = message.client.queue.get(message.guild.id);
     if (!queue) return message.reply("There is nothing playing.").catch(console.error);
     const song = queue.songs[0];
+    const seek = (queue.connection.dispatcher.streamTime - queue.connection.dispatcher.pausedTime) / 1000;
+    const left = song.duration - seek;
 
     let nowPlaying = new MessageEmbed()
       .setTitle("Now playing")
       .setDescription(`${song.title}\n${song.url}`)
       .setColor("#F8AA2A")
       .setAuthor("EvoBot")
-      .setTimestamp();
+      .addField("\u200b", new Date(seek * 1000).toISOString().substr(11, 8) + "[" + createBar((song.duration == 0 ? seek : song.duration), seek, 20)[0] + "]" + (song.duration == 0 ? " ◉ LIVE" : new Date(song.duration * 1000).toISOString().substr(11, 8)), false);
 
-    if (song.duration > 0) nowPlaying.setFooter(new Date(song.duration * 1000).toISOString().substr(11, 8));
+    if (song.duration > 0) nowPlaying.setFooter("Time Remaining: " + new Date(left * 1000).toISOString().substr(11, 8));
 
     return message.channel.send(nowPlaying);
   }

--- a/commands/play.js
+++ b/commands/play.js
@@ -72,7 +72,7 @@ module.exports = {
         song = {
           title: trackInfo.title,
           url: trackInfo.permalink_url,
-          duration: trackInfo.duration
+          duration: trackInfo.duration / 1000
         };
       } catch (error) {
         if (error.statusCode === 404)

--- a/include/play.js
+++ b/include/play.js
@@ -75,7 +75,7 @@ module.exports = {
 
     const filter = (reaction, user) => user.id !== message.client.user.id;
     var collector = playingMessage.createReactionCollector(filter, {
-      time: song.duration > 0 ? song.duration * 1000 : 600000
+      time: song.duration > 0 ? song.duration : 600000
     });
 
     collector.on("collect", (reaction, user) => {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lyrics-finder": "^21.0.5",
     "simple-youtube-api": "^5.1.1",
     "soundcloud-downloader": "^0.1.2",
+    "string-progressbar": "^1.0.1",
     "ytdl-core": "^3.1.0",
     "ytdl-core-discord": "^1.2.1"
   },


### PR DESCRIPTION
* Now playing command now shows progess bar with music seek time and music duration into human readable format
* Supports soundcloud durations too
* Livestreams shows `LIVE` in place of duration after the progressbar. (Progressbar is fixed for livestreams)
* Time remaining doesnt show in case of livestream

This enhancement in made to talk upon issue #146 