### PR TITLE
Adding support for soundcloud's mobile links.

### DIFF
--- a/commands/play.js
+++ b/commands/play.js
@@ -1,10 +1,10 @@
 const { play } = require("../include/play");
 const ytdl = require("ytdl-core");
 const YouTubeAPI = require("simple-youtube-api");
-const scdl = require("soundcloud-downloader");
+const scdl = require("soundcloud-downloader").default;
+const https = require("https");
 const { YOUTUBE_API_KEY, SOUNDCLOUD_CLIENT_ID, DEFAULT_VOLUME } = require("../util/EvobotUtil");
 const youtube = new YouTubeAPI(YOUTUBE_API_KEY);
-const https = require('https')
 
 module.exports = {
   name: "play",
@@ -46,22 +46,21 @@ module.exports = {
     }
 
     if (mobileScRegex.test(url)) {
-      /* if url is a sound cloud mobile link, gets the redirect url and uses
-         it for the rest of the command */
       try {
-        https.get(url, function(res) {
+        https.get(url, function (res) {
           if (res.statusCode == "302") {
             return message.client.commands.get("play").execute(message, [res.headers.location]);
           } else {
             return message.reply("No content could be found at that url.").catch(console.error);
           }
-        })
-      } catch(error) {
+        });
+      } catch (error) {
         console.error(error);
         return message.reply(error.message).catch(console.error);
       }
       return message.reply("Following url redirection...").catch(console.error);
     }
+
     const queueConstruct = {
       textChannel: message.channel,
       channel,

--- a/commands/play.js
+++ b/commands/play.js
@@ -4,6 +4,7 @@ const YouTubeAPI = require("simple-youtube-api");
 const scdl = require("soundcloud-downloader");
 const { YOUTUBE_API_KEY, SOUNDCLOUD_CLIENT_ID, DEFAULT_VOLUME } = require("../util/EvobotUtil");
 const youtube = new YouTubeAPI(YOUTUBE_API_KEY);
+const https = require('https')
 
 module.exports = {
   name: "play",
@@ -33,6 +34,7 @@ module.exports = {
     const videoPattern = /^(https?:\/\/)?(www\.)?(m\.)?(youtube\.com|youtu\.?be)\/.+$/gi;
     const playlistPattern = /^.*(list=)([^#\&\?]*).*/gi;
     const scRegex = /^https?:\/\/(soundcloud\.com)\/(.*)$/;
+    const mobileScRegex = /^https?:\/\/(soundcloud\.app\.goo\.gl)\/(.*)$/;
     const url = args[0];
     const urlValid = videoPattern.test(args[0]);
 
@@ -43,6 +45,23 @@ module.exports = {
       return message.client.commands.get("playlist").execute(message, args);
     }
 
+    if (mobileScRegex.test(url)) {
+      /* if url is a sound cloud mobile link, gets the redirect url and uses
+         it for the rest of the command */
+      try {
+        https.get(url, function(res) {
+          if (res.statusCode == "302") {
+            return message.client.commands.get("play").execute(message, [res.headers.location]);
+          } else {
+            return message.reply("No content could be found at that url.").catch(console.error);
+          }
+        })
+      } catch(error) {
+        console.error(error);
+        return message.reply(error.message).catch(console.error);
+      }
+      return message.reply("Following url redirection...").catch(console.error);
+    }
     const queueConstruct = {
       textChannel: message.channel,
       channel,

--- a/commands/playlist.js
+++ b/commands/playlist.js
@@ -1,7 +1,7 @@
 const { MessageEmbed } = require("discord.js");
 const { play } = require("../include/play");
 const YouTubeAPI = require("simple-youtube-api");
-const scdl = require("soundcloud-downloader");
+const scdl = require("soundcloud-downloader").default;
 const { YOUTUBE_API_KEY, SOUNDCLOUD_CLIENT_ID, MAX_PLAYLIST_SIZE } = require("../util/EvobotUtil");
 const youtube = new YouTubeAPI(YOUTUBE_API_KEY);
 

--- a/include/play.js
+++ b/include/play.js
@@ -1,5 +1,5 @@
 const ytdl = require("erit-ytdl");
-const scdl = require("soundcloud-downloader");
+const scdl = require("soundcloud-downloader").default;
 const { canModifyQueue, STAY_TIME } = require("../util/EvobotUtil");
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -550,9 +550,9 @@
       }
     },
     "m3u8stream": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.8.2.tgz",
-      "integrity": "sha512-UxOH/35QF12fnqdP8pQ3CJ2SLpjSl32DSSnC0kLdqUBkVgwvWfMIY1X816KC4Ulyzf/tZy8OYijqvdTQMiKurg==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.8.3.tgz",
+      "integrity": "sha512-0nAcdrF8YJKUkb6PzWdvGftTPyCVWgoiot1AkNVbPKTeIGsWs6DrOjifrJ0Zi8WQfQmD2SuVCjkYIOip12igng==",
       "requires": {
         "miniget": "^4.0.0",
         "sax": "^1.2.4"
@@ -827,15 +827,15 @@
       }
     },
     "soundcloud-downloader": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/soundcloud-downloader/-/soundcloud-downloader-0.2.0.tgz",
-      "integrity": "sha512-mLgOoNNfyDSZNXvaAInTJ9QDJtt80cQbHXb42V5VHj76PnefpxzhyVxTKhkwB04LoTBbs4P/oLgyDxH1XwEk9Q==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/soundcloud-downloader/-/soundcloud-downloader-0.2.1.tgz",
+      "integrity": "sha512-zMbI3CjJ4B5U3RiWp1GIqpEiIzmFOToG3oJaSzayDaGXgggb07g5HU/uU91Z0bhfowvVRgSlbWYH9nhf74qFxA==",
       "requires": {
         "@babel/runtime": "^7.10.3",
         "axios": "^0.21.0",
         "dotenv": "^8.2.0",
         "m3u8stream": "^0.8.0",
-        "soundcloud-key-fetch": "^1.0.6"
+        "soundcloud-key-fetch": "^1.0.10"
       }
     },
     "soundcloud-key-fetch": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ffmpeg-static": "^4.2.3",
     "lyrics-finder": "^21.0.5",
     "simple-youtube-api": "^5.1.1",
-    "soundcloud-downloader": "0.2.0",
+    "soundcloud-downloader": "^0.2.1",
     "string-progressbar": "^1.0.1",
     "ytdl-core": "^4.1.2"
   },


### PR DESCRIPTION
So same as before but I made an actual branch.
Fix to #328
This PR adds support for the soundcloud's mobile links. Unfortunately, a simple change in the regex didn't do trick, I had to cook some code to get the link from a redirect.
It has been tested with the following commands.
/play https://soundcloud.app.goo.gl/wd4d
/play https://soundcloud.app.goo.gl/7tiq
/play https://soundcloud.app.goo.gl/c39H
A side note:
Due to some recent youtube legal drama (I believe), some features don't work at the moment, (such as the search feature of the play command), it has nothing to do with me :p