### PR TITLE
Add Support for Default Volume on Playlists

### DIFF
--- a/commands/playlist.js
+++ b/commands/playlist.js
@@ -2,7 +2,7 @@ const { MessageEmbed } = require("discord.js");
 const { play } = require("../include/play");
 const YouTubeAPI = require("simple-youtube-api");
 const scdl = require("soundcloud-downloader").default;
-const { YOUTUBE_API_KEY, SOUNDCLOUD_CLIENT_ID, MAX_PLAYLIST_SIZE } = require("../util/EvobotUtil");
+const { YOUTUBE_API_KEY, SOUNDCLOUD_CLIENT_ID, MAX_PLAYLIST_SIZE, DEFAULT_VOLUME } = require("../util/EvobotUtil");
 const youtube = new YouTubeAPI(YOUTUBE_API_KEY);
 
 module.exports = {
@@ -40,7 +40,7 @@ module.exports = {
       connection: null,
       songs: [],
       loop: false,
-      volume: 100,
+      volume: DEFAULT_VOLUME || 100,
       playing: true
     };
 


### PR DESCRIPTION
Currently when you play a playlist it ignores the default volume. I updated the playlist command to use the default volume (if set) when constructing the playlist queue.