### PR TITLE
Add refresh-commands.js to create/update global application command

### DIFF
--- a/commands/clip.js
+++ b/commands/clip.js
@@ -5,6 +5,14 @@ i18n.setLocale(LOCALE);
 module.exports = {
   name: "clip",
   description: i18n.__('clip.description'),
+  slashargs: [
+    {
+      "name": "NAME",
+      "description": i18n.__mf("clip.usageReply", { prefix: PREFIX }), 
+      "type": 3,
+      "required": true
+    }
+  ],
   async execute(message, args) {
     const { channel } = message.member.voice;
     const queue = message.client.queue.get(message.guild.id);

--- a/commands/move.js
+++ b/commands/move.js
@@ -1,5 +1,5 @@
 const move = require("array-move");
-const { canModifyQueue, LOCALE } = require("../util/EvobotUtil");
+const { canModifyQueue, LOCALE, PREFIX } = require("../util/EvobotUtil");
 const i18n = require("i18n");
 
 i18n.setLocale(LOCALE);
@@ -8,6 +8,14 @@ module.exports = {
   name: "move",
   aliases: ["mv"],
   description: i18n.__("move.description"),
+  slashargs: [
+    {
+      "name": "queue-number",
+      "description": i18n.__mf("move.usageReply", { prefix: PREFIX }), 
+      "type": 3,
+      "required": true
+    }
+  ],
   execute(message, args) {
     const queue = message.client.queue.get(message.guild.id);
     if (!queue) return message.channel.send(i18n.__("move.errorNotQueue")).catch(console.error);

--- a/commands/play.js
+++ b/commands/play.js
@@ -3,7 +3,7 @@ const ytdl = require("ytdl-core");
 const YouTubeAPI = require("simple-youtube-api");
 const scdl = require("soundcloud-downloader").default
 const https = require("https");
-const { YOUTUBE_API_KEY, SOUNDCLOUD_CLIENT_ID, LOCALE, DEFAULT_VOLUME } = require("../util/EvobotUtil");
+const { YOUTUBE_API_KEY, SOUNDCLOUD_CLIENT_ID, LOCALE, DEFAULT_VOLUME, PREFIX } = require("../util/EvobotUtil");
 const youtube = new YouTubeAPI(YOUTUBE_API_KEY);
 const i18n = require("i18n");
 
@@ -14,6 +14,14 @@ module.exports = {
   cooldown: 3,
   aliases: ["p"],
   description: i18n.__("play.description"),
+  slashargs: [
+    {
+      "name": "url",
+      "description": i18n.__mf("play.usageReply", { prefix: PREFIX }), 
+      "type": 3,
+      "required": true
+    }
+  ],
   async execute(message, args) {
     const { channel } = message.member.voice;
 

--- a/commands/playlist.js
+++ b/commands/playlist.js
@@ -8,7 +8,8 @@ const {
   SOUNDCLOUD_CLIENT_ID,
   MAX_PLAYLIST_SIZE,
   DEFAULT_VOLUME,
-  LOCALE
+  LOCALE,
+  PREFIX
 } = require("../util/EvobotUtil");
 const youtube = new YouTubeAPI(YOUTUBE_API_KEY);
 const i18n = require("i18n");
@@ -20,6 +21,14 @@ module.exports = {
   cooldown: 5,
   aliases: ["pl"],
   description: i18n.__("playlist.description"),
+  slashargs: [
+    {
+      "name": "url",
+      "description": i18n.__mf("playlist.usageReply", { prefix: PREFIX }), 
+      "type": 3,
+      "required": true
+    }
+  ],
   async execute(message, args) {
     const { channel } = message.member.voice;
     const serverQueue = message.client.queue.get(message.guild.id);

--- a/commands/remove.js
+++ b/commands/remove.js
@@ -1,4 +1,4 @@
-const { canModifyQueue, LOCALE } = require("../util/EvobotUtil");
+const { canModifyQueue, LOCALE, PREFIX } = require("../util/EvobotUtil");
 const i18n = require("i18n");
 i18n.setLocale(LOCALE);
 
@@ -8,6 +8,14 @@ module.exports = {
   name: "remove",
   aliases: ["rm"],
   description: i18n.__("remove.description"),
+  slashargs: [
+    {
+      "name": "queue-number",
+      "description": i18n.__mf("remove.usageReply", { prefix: PREFIX }), 
+      "type": 3,
+      "required": true
+    }
+  ],
   execute(message, args) {
     const queue = message.client.queue.get(message.guild.id);
 

--- a/commands/search.js
+++ b/commands/search.js
@@ -1,6 +1,6 @@
 const { MessageEmbed } = require("discord.js");
 const YouTubeAPI = require("simple-youtube-api");
-const { YOUTUBE_API_KEY, LOCALE } = require("../util/EvobotUtil");
+const { YOUTUBE_API_KEY, LOCALE, PREFIX } = require("../util/EvobotUtil");
 const youtube = new YouTubeAPI(YOUTUBE_API_KEY);
 const i18n = require("i18n");
 
@@ -9,6 +9,14 @@ i18n.setLocale(LOCALE);
 module.exports = {
   name: "search",
   description: i18n.__("search.description"),
+  slashargs: [
+    {
+      "name": "video-name",
+      "description": i18n.__mf("search.usageReply", { prefix: PREFIX }), 
+      "type": 3,
+      "required": true
+    }
+  ],
   async execute(message, args) {
     if (!args.length)
       return message

--- a/commands/skipto.js
+++ b/commands/skipto.js
@@ -1,4 +1,4 @@
-const { canModifyQueue, LOCALE } = require("../util/EvobotUtil");
+const { canModifyQueue, LOCALE, PREFIX } = require("../util/EvobotUtil");
 const i18n = require("i18n");
 
 i18n.setLocale(LOCALE);
@@ -7,6 +7,14 @@ module.exports = {
   name: "skipto",
   aliases: ["st"],
   description: i18n.__("skipto.description"),
+  slashargs: [
+    {
+      "name": "queue-number",
+      "description": i18n.__mf("skipto.usageReply", { prefix: PREFIX }), 
+      "type": 3,
+      "required": true
+    }
+  ],
   execute(message, args) {
     if (!args.length || isNaN(args[0]))
       return message

--- a/index.js
+++ b/index.js
@@ -4,9 +4,8 @@
 const { Client, Collection } = require("discord.js");
 const { readdirSync } = require("fs");
 const { join } = require("path");
-const { TOKEN, PREFIX, LOCALE } = require("./util/EvobotUtil");
-const path = require("path");
-const i18n = require("i18n");
+const { TOKEN, PREFIX } = require("./util/EvobotUtil");
+const { initI18n } = require("./locale");
 
 const client = new Client({ 
   disableMentions: "everyone",
@@ -20,30 +19,7 @@ client.queue = new Map();
 const cooldowns = new Collection();
 const escapeRegex = (str) => str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
-i18n.configure({
-  locales: ["en", "es", "ko", "fr", "tr", "pt_br", "zh_cn", "zh_tw"],
-  directory: path.join(__dirname, "locales"),
-  defaultLocale: "en",
-  objectNotation: true,
-  register: global,
-
-  logWarnFn: function (msg) {
-    console.log("warn", msg);
-  },
-
-  logErrorFn: function (msg) {
-    console.log("error", msg);
-  },
-
-  missingKeyFn: function (locale, value) {
-    return value;
-  },
-
-  mustacheConfig: {
-    tags: ["{{", "}}"],
-    disable: false
-  }
-});
+initI18n()
 
 /**
  * Client Events

--- a/locale.js
+++ b/locale.js
@@ -1,0 +1,31 @@
+const i18n = require("i18n");
+const path = require("path");
+
+module.exports = {
+  initI18n() {
+    i18n.configure({
+      locales: ["en", "es", "ko", "fr", "tr", "pt_br", "zh_cn", "zh_tw"],
+      directory: path.join(__dirname, "locales"),
+      defaultLocale: "en",
+      objectNotation: true,
+      register: global,
+
+      logWarnFn: function (msg) {
+        console.log("warn", msg);
+      },
+
+      logErrorFn: function (msg) {
+        console.log("error", msg);
+      },
+
+      missingKeyFn: function (locale, value) {
+        return value;
+      },
+
+      mustacheConfig: {
+        tags: ["{{", "}}"],
+        disable: false
+      }
+    });
+  }
+};

--- a/locales/ko.json
+++ b/locales/ko.json
@@ -1,7 +1,7 @@
 {
   "clip": {
     "description": "주어진 클립을 재생합니다.",
-    "usagesReply": "Usage: /clip <name>",
+    "usageReply": "Usage: /clip <name>",
     "errorQueue": "대기열에 음악이 있을 경우 클립을 재생할 수 없습니다.",
     "errorNotChannel": "음성 채널에 들어와 있지 않습니다."
   },
@@ -30,7 +30,7 @@
   "move": {
     "description": "대기열에서 음악을 이동합니다.",
     "errorNotQueue": "대기열에 음악이 없습니다.",
-    "usagesReply": "사용 방법: {prefix}move <Queue Number>",
+    "usageReply": "사용 방법: {prefix}move <Queue Number>",
     "result": "<@{author}> 🚚 **{title}** 를 대기열에서 {index}번째로 옮겼습니다."
   },
   "nowplaying": {
@@ -74,7 +74,7 @@
   },
   "playlist": {
     "description": "Youtube 부터 재생목록을 재생합니다.",
-    "usagesReply": "사용 방법: {prefix}playlist <YouTube Playlist URL | Playlist Name>",
+    "usageReply": "사용 방법: {prefix}playlist <YouTube Playlist URL | Playlist Name>",
     "errorNotChannel": "음성 채널에 들어와 있지 않습니다.",
     "errorNotInSameChannel": "{user} 와 같은 음성 채널에 들어와 있어야 합니다.",
     "missingPermissionConnect": "음성 채널에 들어갈 수 없습니다. 권한을 확인해 주세요.",

--- a/refresh-commands.js
+++ b/refresh-commands.js
@@ -1,0 +1,45 @@
+const { readdirSync } = require("fs");
+const { join } = require("path");
+const { TOKEN } = require("./util/EvobotUtil");
+const { initI18n } = require("./locale");
+const fetch = require('node-fetch');
+var _ = require('lodash');
+
+var applicationId = process.argv[2];
+if (_.isEmpty(applicationId)) {
+    const message = `
+Create/Update Global Application Command
+Docs: https://discord.com/developers/docs/interactions/slash-commands#registering-a-command
+
+This script will refresh command list of evobot to discord command section(https://i.stack.imgur.com/5tDg1.png).
+
+Usage: node refresh-commands {applicationId}
+'applicationId' can be found on discord developer portal (https://discord.com/developers/applications)
+
+ex) If application id is 123456789123456789, it will be 'node refresh-commands 123456789123456789'
+    `
+    console.log(message)
+    throw 'application id is missing'
+}
+
+initI18n()
+
+const commandFiles = readdirSync(join(__dirname, "commands")).filter((file) => file.endsWith(".js"));
+const commandList = []
+for (const file of commandFiles) {
+  const command = require(join(__dirname, "commands", `${file}`));
+  commandList.push({
+      "name": command.name,
+      "description": command.description
+  })
+}
+
+const requestUrl = `https://discord.com/api/v8/applications/${applicationId}/commands`
+const requestHeader = { 'Authorization': `Bot ${TOKEN}`, 'Content-Type': 'application/json' }
+
+commandList.forEach(element => {
+    const requestBody = JSON.stringify(element)
+    fetch(requestUrl, { method: "post", body: requestBody, headers: requestHeader })
+      .then(res => res.json())
+      .then(json => console.log(json))
+})

--- a/refresh-commands.js
+++ b/refresh-commands.js
@@ -11,7 +11,7 @@ if (_.isEmpty(applicationId)) {
 Create/Update Global Application Command
 Docs: https://discord.com/developers/docs/interactions/slash-commands#registering-a-command
 
-This script will refresh command list of evobot to discord command section(https://i.stack.imgur.com/5tDg1.png).
+This script will refresh command list of evobot to discord command section(https://discord.com/assets/a660b11b63a95e932719346ff67ea60f.png).
 
 Usage: node refresh-commands {applicationId}
 'applicationId' can be found on discord developer portal (https://discord.com/developers/applications)

--- a/refresh-commands.js
+++ b/refresh-commands.js
@@ -30,7 +30,8 @@ for (const file of commandFiles) {
   const command = require(join(__dirname, "commands", `${file}`));
   commandList.push({
       "name": command.name,
-      "description": command.description
+      "description": command.description,
+      "options": command.slashargs || []
   })
 }
 


### PR DESCRIPTION
This PR makes show commands list of `evobot` in discord command section

![a660b11b63a95e932719346ff67ea60f](https://user-images.githubusercontent.com/3054645/106145297-b399a600-61b8-11eb-8c5e-05d16eb12e36.png)

Usage: node refresh-commands {applicationId}
ex) node refresh-commands 123456789123456789

**OBJECTIVE**
* collect name, description and send request to discord api server
* refactor initialization of i18n(#350) into locale.js 
