### PR TITLE
Dj role permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ Copy or Rename `config.json.example` to `config.json` and fill out the values:
   "PRUNING": false,
   "LOCALE": "en",
   "DEFAULT_VOLUME": 100,
-  "STAY_TIME": 30
+  "STAY_TIME": 30,
+  "DJ_ROLE": "",
+  "DJ_COMMANDS", "stop,skip,volume"
 }
 ```
 
@@ -107,6 +109,7 @@ Examples: `1` or `1,2,3`
 * Help (/help, /h)
 * Command Handler from [discordjs.guide](https://discordjs.guide/)
 * Media Controls via Reactions
+* DJ Role permissions
 
 ![reactions](https://i.imgur.com/9S7Omf9.png)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Copy or Rename `config.json.example` to `config.json` and fill out the values:
   "DEFAULT_VOLUME": 100,
   "STAY_TIME": 30,
   "DJ_ROLE": "",
-  "DJ_COMMANDS", "stop,skip,volume"
+  "DJ_COMMANDS": "stop,skip,volume"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Copy or Rename `config.json.example` to `config.json` and fill out the values:
   "DEFAULT_VOLUME": 100,
   "STAY_TIME": 30,
   "DJ_ROLE": "",
-  "DJ_COMMANDS": ""
+  "DJ_COMMANDS": []
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Copy or Rename `config.json.example` to `config.json` and fill out the values:
   "DEFAULT_VOLUME": 100,
   "STAY_TIME": 30,
   "DJ_ROLE": "",
-  "DJ_COMMANDS": "stop,skip,volume"
+  "DJ_COMMANDS": ""
 }
 ```
 

--- a/config.json.example
+++ b/config.json.example
@@ -8,5 +8,6 @@
   "LOCALE": "en",
   "STAY_TIME": 30,
   "DEFAULT_VOLUME": 100,
-  "DJ_ROLE":""
+  "DJ_ROLE":"",
+  "DJ_COMMANDS":"loop,move,pause,pruning,remove,shuffle,skip,skipto,volume,stop"
 }

--- a/config.json.example
+++ b/config.json.example
@@ -7,5 +7,6 @@
   "PRUNING": false,
   "LOCALE": "en",
   "STAY_TIME": 30,
-  "DEFAULT_VOLUME": 100
+  "DEFAULT_VOLUME": 100,
+  "DJ_ROLE":""
 }

--- a/config.json.example
+++ b/config.json.example
@@ -9,5 +9,5 @@
   "STAY_TIME": 30,
   "DEFAULT_VOLUME": 100,
   "DJ_ROLE":"",
-  "DJ_COMMANDS":"loop,move,pause,pruning,remove,shuffle,skip,skipto,volume,stop"
+  "DJ_COMMANDS":["loop","move","pause","pruning","remove","shuffle","skip","skipto","volume","stop"]
 }

--- a/include/play.js
+++ b/include/play.js
@@ -112,7 +112,7 @@ module.exports = {
           queue.playing = true;
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly('skip',member,message)) i18n.__("common.errorDJOnly");
+          if (!isDJOnly('skip',member,message.guild)) i18n.__("common.errorDJOnly");
           queue.connection.dispatcher.end();
           queue.textChannel.send(i18n.__mf("play.skipSong", { author: user })).catch(console.error);
           collector.stop();
@@ -121,7 +121,7 @@ module.exports = {
         case "⏯": //pause
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly('pause',member,message)) return i18n.__("common.errorDJOnly");
+          if (!isDJOnly('pause',member,message.guild)) return i18n.__("common.errorDJOnly");
           if (queue.playing) {
             queue.playing = !queue.playing;
             queue.connection.dispatcher.pause(true);
@@ -136,7 +136,7 @@ module.exports = {
         case "🔇": //mute
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly('volume',member,message)) i18n.__("common.errorDJOnly");
+          if (!isDJOnly('volume',member,message.guild)) i18n.__("common.errorDJOnly");
           if (queue.volume <= 0) {
             queue.volume = 100;
             queue.connection.dispatcher.setVolumeLogarithmic(100 / 100);
@@ -152,7 +152,7 @@ module.exports = {
           reaction.users.remove(user).catch(console.error);
           if (queue.volume == 0) return;
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly('volume',member,message)) i18n.__("common.errorDJOnly");
+          if (!isDJOnly('volume',member,message.guild)) i18n.__("common.errorDJOnly");
           if (queue.volume - 10 <= 0) queue.volume = 0;
           else queue.volume = queue.volume - 10;
           queue.connection.dispatcher.setVolumeLogarithmic(queue.volume / 100);
@@ -165,7 +165,7 @@ module.exports = {
           reaction.users.remove(user).catch(console.error);
           if (queue.volume == 100) return;
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly('volume',member,message)) i18n.__("common.errorDJOnly");
+          if (!isDJOnly('volume',member,message.guild)) i18n.__("common.errorDJOnly");
           if (queue.volume + 10 >= 100) queue.volume = 100;
           else queue.volume = queue.volume + 10;
           queue.connection.dispatcher.setVolumeLogarithmic(queue.volume / 100);
@@ -177,7 +177,7 @@ module.exports = {
         case "🔁": // loop
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly('loop',member,message)) i18n.__("common.errorDJOnly");
+          if (!isDJOnly('loop',member,message.guild)) i18n.__("common.errorDJOnly");
           queue.loop = !queue.loop;
           queue.textChannel
             .send(
@@ -192,7 +192,7 @@ module.exports = {
         case "⏹": // stop
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly('stop',member,message)) i18n.__("common.errorDJOnly");
+          if (!isDJOnly('stop',member,message.guild)) i18n.__("common.errorDJOnly");
           queue.songs = [];
           queue.textChannel.send(i18n.__mf("play.stopSong", { author: user })).catch(console.error);
           try {

--- a/include/play.js
+++ b/include/play.js
@@ -136,7 +136,7 @@ module.exports = {
         case "🔇": //mute
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (isDJOnly('volume',member,message.guild)) i18n.__mf("common.errorDJOnly",{DJ_ROLE:DJ_ROLE});
+          if (isDJOnly('volume',member,message.guild)) return i18n.__mf("common.errorDJOnly",{DJ_ROLE:DJ_ROLE});
           if (queue.volume <= 0) {
             queue.volume = 100;
             queue.connection.dispatcher.setVolumeLogarithmic(100 / 100);

--- a/include/play.js
+++ b/include/play.js
@@ -121,7 +121,7 @@ module.exports = {
         case "⏯": //pause
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly('pause',member,message.guild)) return i18n.__("common.errorDJOnly");
+          if (isDJOnly('pause',member,message.guild)) return i18n.__("common.errorDJOnly");
           if (queue.playing) {
             queue.playing = !queue.playing;
             queue.connection.dispatcher.pause(true);
@@ -136,7 +136,7 @@ module.exports = {
         case "🔇": //mute
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly('volume',member,message.guild)) i18n.__("common.errorDJOnly");
+          if (isDJOnly('volume',member,message.guild)) i18n.__("common.errorDJOnly");
           if (queue.volume <= 0) {
             queue.volume = 100;
             queue.connection.dispatcher.setVolumeLogarithmic(100 / 100);
@@ -152,7 +152,7 @@ module.exports = {
           reaction.users.remove(user).catch(console.error);
           if (queue.volume == 0) return;
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly('volume',member,message.guild)) i18n.__("common.errorDJOnly");
+          if (isDJOnly('volume',member,message.guild)) i18n.__("common.errorDJOnly");
           if (queue.volume - 10 <= 0) queue.volume = 0;
           else queue.volume = queue.volume - 10;
           queue.connection.dispatcher.setVolumeLogarithmic(queue.volume / 100);
@@ -165,7 +165,7 @@ module.exports = {
           reaction.users.remove(user).catch(console.error);
           if (queue.volume == 100) return;
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly('volume',member,message.guild)) i18n.__("common.errorDJOnly");
+          if (isDJOnly('volume',member,message.guild)) i18n.__("common.errorDJOnly");
           if (queue.volume + 10 >= 100) queue.volume = 100;
           else queue.volume = queue.volume + 10;
           queue.connection.dispatcher.setVolumeLogarithmic(queue.volume / 100);
@@ -177,7 +177,7 @@ module.exports = {
         case "🔁": // loop
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly('loop',member,message.guild)) i18n.__("common.errorDJOnly");
+          if (isDJOnly('loop',member,message.guild)) i18n.__("common.errorDJOnly");
           queue.loop = !queue.loop;
           queue.textChannel
             .send(
@@ -192,7 +192,7 @@ module.exports = {
         case "⏹": // stop
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly('stop',member,message.guild)) i18n.__("common.errorDJOnly");
+          if (isDJOnly('stop',member,message.guild)) i18n.__("common.errorDJOnly");
           queue.songs = [];
           queue.textChannel.send(i18n.__mf("play.stopSong", { author: user })).catch(console.error);
           try {

--- a/include/play.js
+++ b/include/play.js
@@ -112,7 +112,7 @@ module.exports = {
           queue.playing = true;
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly(member,message)) i18n.__("common.errorDJOnly");
+          if (!isDJOnly('skip',member,message)) i18n.__("common.errorDJOnly");
           queue.connection.dispatcher.end();
           queue.textChannel.send(i18n.__mf("play.skipSong", { author: user })).catch(console.error);
           collector.stop();
@@ -121,7 +121,7 @@ module.exports = {
         case "⏯": //pause
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly(member,message)) return i18n.__("common.errorDJOnly");
+          if (!isDJOnly('pause',member,message)) return i18n.__("common.errorDJOnly");
           if (queue.playing) {
             queue.playing = !queue.playing;
             queue.connection.dispatcher.pause(true);
@@ -136,7 +136,7 @@ module.exports = {
         case "🔇": //mute
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly(member,message)) i18n.__("common.errorDJOnly");
+          if (!isDJOnly('volume',member,message)) i18n.__("common.errorDJOnly");
           if (queue.volume <= 0) {
             queue.volume = 100;
             queue.connection.dispatcher.setVolumeLogarithmic(100 / 100);
@@ -152,7 +152,7 @@ module.exports = {
           reaction.users.remove(user).catch(console.error);
           if (queue.volume == 0) return;
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly(member,message)) i18n.__("common.errorDJOnly");
+          if (!isDJOnly('volume',member,message)) i18n.__("common.errorDJOnly");
           if (queue.volume - 10 <= 0) queue.volume = 0;
           else queue.volume = queue.volume - 10;
           queue.connection.dispatcher.setVolumeLogarithmic(queue.volume / 100);
@@ -165,7 +165,7 @@ module.exports = {
           reaction.users.remove(user).catch(console.error);
           if (queue.volume == 100) return;
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly(member,message)) i18n.__("common.errorDJOnly");
+          if (!isDJOnly('volume',member,message)) i18n.__("common.errorDJOnly");
           if (queue.volume + 10 >= 100) queue.volume = 100;
           else queue.volume = queue.volume + 10;
           queue.connection.dispatcher.setVolumeLogarithmic(queue.volume / 100);
@@ -177,7 +177,7 @@ module.exports = {
         case "🔁": // loop
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly(member,message)) i18n.__("common.errorDJOnly");
+          if (!isDJOnly('loop',member,message)) i18n.__("common.errorDJOnly");
           queue.loop = !queue.loop;
           queue.textChannel
             .send(
@@ -192,7 +192,7 @@ module.exports = {
         case "⏹": // stop
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly(member,message)) i18n.__("common.errorDJOnly");
+          if (!isDJOnly('stop',member,message)) i18n.__("common.errorDJOnly");
           queue.songs = [];
           queue.textChannel.send(i18n.__mf("play.stopSong", { author: user })).catch(console.error);
           try {

--- a/include/play.js
+++ b/include/play.js
@@ -1,8 +1,9 @@
 const ytdl = require("ytdl-core-discord");
 const scdl = require("soundcloud-downloader").default;
-const { canModifyQueue, STAY_TIME, LOCALE } = require("../util/EvobotUtil");
+const { canModifyQueue, STAY_TIME, LOCALE, isDJOnly } = require("../util/EvobotUtil");
 const i18n = require("i18n");
 i18n.setLocale(LOCALE);
+
 
 module.exports = {
   async play(song, message) {
@@ -107,18 +108,20 @@ module.exports = {
       const member = message.guild.member(user);
 
       switch (reaction.emoji.name) {
-        case "⏭":
+        case "⏭": //skip
           queue.playing = true;
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
+          if (!isDJOnly(member,message)) return false;
           queue.connection.dispatcher.end();
           queue.textChannel.send(i18n.__mf("play.skipSong", { author: user })).catch(console.error);
           collector.stop();
           break;
 
-        case "⏯":
+        case "⏯": //pause
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
+          if (!isDJOnly(member,message)) return false;
           if (queue.playing) {
             queue.playing = !queue.playing;
             queue.connection.dispatcher.pause(true);
@@ -130,9 +133,10 @@ module.exports = {
           }
           break;
 
-        case "🔇":
+        case "🔇": //mute
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
+          if (!isDJOnly(member,message)) return false;
           if (queue.volume <= 0) {
             queue.volume = 100;
             queue.connection.dispatcher.setVolumeLogarithmic(100 / 100);
@@ -144,10 +148,11 @@ module.exports = {
           }
           break;
 
-        case "🔉":
+        case "🔉": //volume down
           reaction.users.remove(user).catch(console.error);
           if (queue.volume == 0) return;
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
+          if (!isDJOnly(member,message)) return false;
           if (queue.volume - 10 <= 0) queue.volume = 0;
           else queue.volume = queue.volume - 10;
           queue.connection.dispatcher.setVolumeLogarithmic(queue.volume / 100);
@@ -156,10 +161,11 @@ module.exports = {
             .catch(console.error);
           break;
 
-        case "🔊":
+        case "🔊": // volume up
           reaction.users.remove(user).catch(console.error);
           if (queue.volume == 100) return;
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
+          if (!isDJOnly(member,message)) return false;
           if (queue.volume + 10 >= 100) queue.volume = 100;
           else queue.volume = queue.volume + 10;
           queue.connection.dispatcher.setVolumeLogarithmic(queue.volume / 100);
@@ -168,9 +174,10 @@ module.exports = {
             .catch(console.error);
           break;
 
-        case "🔁":
+        case "🔁": // loop
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
+          if (!isDJOnly(member,message)) return false;
           queue.loop = !queue.loop;
           queue.textChannel
             .send(
@@ -182,9 +189,10 @@ module.exports = {
             .catch(console.error);
           break;
 
-        case "⏹":
+        case "⏹": // stop
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
+          if (!isDJOnly(member,message)) return false;
           queue.songs = [];
           queue.textChannel.send(i18n.__mf("play.stopSong", { author: user })).catch(console.error);
           try {

--- a/include/play.js
+++ b/include/play.js
@@ -112,7 +112,7 @@ module.exports = {
           queue.playing = true;
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly(member,message)) return false;
+          if (!isDJOnly(member,message)) i18n.__("common.errorDJOnly");
           queue.connection.dispatcher.end();
           queue.textChannel.send(i18n.__mf("play.skipSong", { author: user })).catch(console.error);
           collector.stop();
@@ -121,7 +121,7 @@ module.exports = {
         case "⏯": //pause
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly(member,message)) return false;
+          if (!isDJOnly(member,message)) return i18n.__("common.errorDJOnly");
           if (queue.playing) {
             queue.playing = !queue.playing;
             queue.connection.dispatcher.pause(true);
@@ -136,7 +136,7 @@ module.exports = {
         case "🔇": //mute
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly(member,message)) return false;
+          if (!isDJOnly(member,message)) i18n.__("common.errorDJOnly");
           if (queue.volume <= 0) {
             queue.volume = 100;
             queue.connection.dispatcher.setVolumeLogarithmic(100 / 100);
@@ -152,7 +152,7 @@ module.exports = {
           reaction.users.remove(user).catch(console.error);
           if (queue.volume == 0) return;
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly(member,message)) return false;
+          if (!isDJOnly(member,message)) i18n.__("common.errorDJOnly");
           if (queue.volume - 10 <= 0) queue.volume = 0;
           else queue.volume = queue.volume - 10;
           queue.connection.dispatcher.setVolumeLogarithmic(queue.volume / 100);
@@ -165,7 +165,7 @@ module.exports = {
           reaction.users.remove(user).catch(console.error);
           if (queue.volume == 100) return;
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly(member,message)) return false;
+          if (!isDJOnly(member,message)) i18n.__("common.errorDJOnly");
           if (queue.volume + 10 >= 100) queue.volume = 100;
           else queue.volume = queue.volume + 10;
           queue.connection.dispatcher.setVolumeLogarithmic(queue.volume / 100);
@@ -177,7 +177,7 @@ module.exports = {
         case "🔁": // loop
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly(member,message)) return false;
+          if (!isDJOnly(member,message)) i18n.__("common.errorDJOnly");
           queue.loop = !queue.loop;
           queue.textChannel
             .send(
@@ -192,7 +192,7 @@ module.exports = {
         case "⏹": // stop
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly(member,message)) return false;
+          if (!isDJOnly(member,message)) i18n.__("common.errorDJOnly");
           queue.songs = [];
           queue.textChannel.send(i18n.__mf("play.stopSong", { author: user })).catch(console.error);
           try {

--- a/include/play.js
+++ b/include/play.js
@@ -112,7 +112,7 @@ module.exports = {
           queue.playing = true;
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (!isDJOnly('skip',member,message.guild)) i18n.__("common.errorDJOnly");
+          if (isDJOnly('skip',member,message.guild)) return i18n.__("common.errorDJOnly");
           queue.connection.dispatcher.end();
           queue.textChannel.send(i18n.__mf("play.skipSong", { author: user })).catch(console.error);
           collector.stop();
@@ -136,7 +136,7 @@ module.exports = {
         case "🔇": //mute
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (isDJOnly('volume',member,message.guild)) i18n.__("common.errorDJOnly");
+          if (isDJOnly('volume',member,message.guild)) return i18n.__("common.errorDJOnly");
           if (queue.volume <= 0) {
             queue.volume = 100;
             queue.connection.dispatcher.setVolumeLogarithmic(100 / 100);
@@ -152,7 +152,7 @@ module.exports = {
           reaction.users.remove(user).catch(console.error);
           if (queue.volume == 0) return;
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (isDJOnly('volume',member,message.guild)) i18n.__("common.errorDJOnly");
+          if (isDJOnly('volume',member,message.guild)) return i18n.__("common.errorDJOnly");
           if (queue.volume - 10 <= 0) queue.volume = 0;
           else queue.volume = queue.volume - 10;
           queue.connection.dispatcher.setVolumeLogarithmic(queue.volume / 100);
@@ -165,7 +165,7 @@ module.exports = {
           reaction.users.remove(user).catch(console.error);
           if (queue.volume == 100) return;
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (isDJOnly('volume',member,message.guild)) i18n.__("common.errorDJOnly");
+          if (isDJOnly('volume',member,message.guild)) return i18n.__("common.errorDJOnly");
           if (queue.volume + 10 >= 100) queue.volume = 100;
           else queue.volume = queue.volume + 10;
           queue.connection.dispatcher.setVolumeLogarithmic(queue.volume / 100);
@@ -177,7 +177,7 @@ module.exports = {
         case "🔁": // loop
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (isDJOnly('loop',member,message.guild)) i18n.__("common.errorDJOnly");
+          if (isDJOnly('loop',member,message.guild)) return i18n.__("common.errorDJOnly");
           queue.loop = !queue.loop;
           queue.textChannel
             .send(
@@ -192,7 +192,7 @@ module.exports = {
         case "⏹": // stop
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (isDJOnly('stop',member,message.guild)) i18n.__("common.errorDJOnly");
+          if (isDJOnly('stop',member,message.guild)) return i18n.__("common.errorDJOnly");
           queue.songs = [];
           queue.textChannel.send(i18n.__mf("play.stopSong", { author: user })).catch(console.error);
           try {

--- a/include/play.js
+++ b/include/play.js
@@ -1,6 +1,6 @@
 const ytdl = require("ytdl-core-discord");
 const scdl = require("soundcloud-downloader").default;
-const { canModifyQueue, STAY_TIME, LOCALE, isDJOnly } = require("../util/EvobotUtil");
+const { canModifyQueue, STAY_TIME, LOCALE, isDJOnly, DJ_ROLE } = require("../util/EvobotUtil");
 const i18n = require("i18n");
 i18n.setLocale(LOCALE);
 
@@ -112,7 +112,7 @@ module.exports = {
           queue.playing = true;
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (isDJOnly('skip',member,message.guild)) return i18n.__("common.errorDJOnly");
+          if (isDJOnly('skip',member,message.guild)) return i18n.__mf("common.errorDJOnly",{DJ_ROLE:DJ_ROLE});
           queue.connection.dispatcher.end();
           queue.textChannel.send(i18n.__mf("play.skipSong", { author: user })).catch(console.error);
           collector.stop();
@@ -121,7 +121,7 @@ module.exports = {
         case "⏯": //pause
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (isDJOnly('pause',member,message.guild)) return i18n.__("common.errorDJOnly");
+          if (isDJOnly('pause',member,message.guild)) return i18n.__mf("common.errorDJOnly",{DJ_ROLE:DJ_ROLE});
           if (queue.playing) {
             queue.playing = !queue.playing;
             queue.connection.dispatcher.pause(true);
@@ -136,7 +136,7 @@ module.exports = {
         case "🔇": //mute
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (isDJOnly('volume',member,message.guild)) return i18n.__("common.errorDJOnly");
+          if (isDJOnly('volume',member,message.guild)) i18n.__mf("common.errorDJOnly",{DJ_ROLE:DJ_ROLE});
           if (queue.volume <= 0) {
             queue.volume = 100;
             queue.connection.dispatcher.setVolumeLogarithmic(100 / 100);
@@ -152,7 +152,7 @@ module.exports = {
           reaction.users.remove(user).catch(console.error);
           if (queue.volume == 0) return;
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (isDJOnly('volume',member,message.guild)) return i18n.__("common.errorDJOnly");
+          if (isDJOnly('volume',member,message.guild)) return i18n.__mf("common.errorDJOnly",{DJ_ROLE:DJ_ROLE});
           if (queue.volume - 10 <= 0) queue.volume = 0;
           else queue.volume = queue.volume - 10;
           queue.connection.dispatcher.setVolumeLogarithmic(queue.volume / 100);
@@ -165,7 +165,7 @@ module.exports = {
           reaction.users.remove(user).catch(console.error);
           if (queue.volume == 100) return;
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (isDJOnly('volume',member,message.guild)) return i18n.__("common.errorDJOnly");
+          if (isDJOnly('volume',member,message.guild)) return i18n.__mf("common.errorDJOnly",{DJ_ROLE:DJ_ROLE});
           if (queue.volume + 10 >= 100) queue.volume = 100;
           else queue.volume = queue.volume + 10;
           queue.connection.dispatcher.setVolumeLogarithmic(queue.volume / 100);
@@ -177,7 +177,7 @@ module.exports = {
         case "🔁": // loop
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (isDJOnly('loop',member,message.guild)) return i18n.__("common.errorDJOnly");
+          if (isDJOnly('loop',member,message.guild)) return i18n.__mf("common.errorDJOnly",{DJ_ROLE:DJ_ROLE});
           queue.loop = !queue.loop;
           queue.textChannel
             .send(
@@ -192,7 +192,7 @@ module.exports = {
         case "⏹": // stop
           reaction.users.remove(user).catch(console.error);
           if (!canModifyQueue(member)) return i18n.__("common.errorNotChannel");
-          if (isDJOnly('stop',member,message.guild)) return i18n.__("common.errorDJOnly");
+          if (isDJOnly('stop',member,message.guild)) return i18n.__mf("common.errorDJOnly",{DJ_ROLE:DJ_ROLE});
           queue.songs = [];
           queue.textChannel.send(i18n.__mf("play.stopSong", { author: user })).catch(console.error);
           try {

--- a/index.js
+++ b/index.js
@@ -81,6 +81,8 @@ client.on("message", async (message) => {
     client.commands.find((cmd) => cmd.aliases && cmd.aliases.includes(commandName));
 
   if (!command) return;
+  
+  if(isDJOnly(command.name,message.member,message)return;
 
   if (!cooldowns.has(command.name)) {
     cooldowns.set(command.name, new Collection());

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 const { Client, Collection } = require("discord.js");
 const { readdirSync } = require("fs");
 const { join } = require("path");
-const { TOKEN, PREFIX, LOCALE } = require("./util/EvobotUtil");
+const { TOKEN, PREFIX, LOCALE , isDJOnly} = require("./util/EvobotUtil");
 const path = require("path");
 const i18n = require("i18n");
 
@@ -82,7 +82,7 @@ client.on("message", async (message) => {
 
   if (!command) return;
   
-  if(isDJOnly(command.name,message.member,message)return;
+  if(isDJOnly(command.name,message.member,message))return;
 
   if (!cooldowns.has(command.name)) {
     cooldowns.set(command.name, new Collection());

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ i18n.configure({
  */
 client.on("ready", () => {
   console.log(`${client.user.username} ready!`);
-  client.user.setActivity(`🔇. Use ${PREFIX}play to queue up some tunes! For more info use ${PREFIX}help`, { type: "CUSTOM_STATUS" });
+  client.user.setActivity(`Use ${PREFIX}play to queue up some tunes! For more info use ${PREFIX}help`, { type: "WATCHING" });
 });
 client.on("warn", (info) => console.log(info));
 client.on("error", console.error);

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ i18n.configure({
  */
 client.on("ready", () => {
   console.log(`${client.user.username} ready!`);
-  client.user.setActivity(`${PREFIX}help and ${PREFIX}play`, { type: "LISTENING" });
+  client.user.setActivity(`tunes. Type:${PREFIX}help for more info`, { type: "STREAMING" });
 });
 client.on("warn", (info) => console.log(info));
 client.on("error", console.error);

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ client.on("message", async (message) => {
 
   if (!command) return;
   
-  if(isDJOnly(command.name,message.member,message.guild)) return message.reply(i18n.__("common.errorDJOnly"));
+  if(isDJOnly(command.name,message.member,message.guild)) return message.reply(i18n.__mf("common.errorDJOnly",{DJ_ROLE:DJ_ROLE}));
 
   if (!cooldowns.has(command.name)) {
     cooldowns.set(command.name, new Collection());

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ i18n.configure({
  */
 client.on("ready", () => {
   console.log(`${client.user.username} ready!`);
-  client.user.setActivity(`tunes. Type:${PREFIX}help for more info`, { type: "STREAMING" });
+  client.user.setActivity(`🔇. Use ${PREFIX}play to queue up some tunes! For more info use ${PREFIX}help`, { type: "STREAMING" });
 });
 client.on("warn", (info) => console.log(info));
 client.on("error", console.error);

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ i18n.configure({
  */
 client.on("ready", () => {
   console.log(`${client.user.username} ready!`);
-  client.user.setActivity(`Use ${PREFIX}play to queue up some tunes! For more info use ${PREFIX}help`, { type: "WATCHING" });
+  client.user.setActivity(`tunes! Type:${PREFIX}help for more info`, { type: "STREAMING" });
 });
 client.on("warn", (info) => console.log(info));
 client.on("error", console.error);

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ client.on("message", async (message) => {
 
   if (!command) return;
   
-  if(isDJOnly(command.name,message.member,message))return;
+  if(isDJOnly(command.name,message.member,message.guild)) return message.reply(i18n.__("common.errorDJOnly"));
 
   if (!cooldowns.has(command.name)) {
     cooldowns.set(command.name, new Collection());

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ i18n.configure({
  */
 client.on("ready", () => {
   console.log(`${client.user.username} ready!`);
-  client.user.setActivity(`🔇. Use ${PREFIX}play to queue up some tunes! For more info use ${PREFIX}help`, { type: "STREAMING" });
+  client.user.setActivity(`🔇. Use ${PREFIX}play to queue up some tunes! For more info use ${PREFIX}help`, { type: "CUSTOM_STATUS" });
 });
 client.on("warn", (info) => console.log(info));
 client.on("error", console.error);

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 const { Client, Collection } = require("discord.js");
 const { readdirSync } = require("fs");
 const { join } = require("path");
-const { TOKEN, PREFIX, LOCALE , isDJOnly} = require("./util/EvobotUtil");
+const { TOKEN, PREFIX, LOCALE , isDJOnly, DJ_ROLE} = require("./util/EvobotUtil");
 const path = require("path");
 const i18n = require("i18n");
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -160,6 +160,8 @@
     "disabled": "**disabled**",
     "errorNotChannel": "You need to join a voice channel first!",
     "cooldownMessage": "please wait {time} more second(s) before reusing the `{name}` command.",
-    "errorCommend": "There was an error executing that command."
+    "errorCommend": "There was an error executing that command.",
+    "errorDJOnly": "Only users with the {DJ_ROLE} role can access this feature!")
+
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -161,7 +161,6 @@
     "errorNotChannel": "You need to join a voice channel first!",
     "cooldownMessage": "please wait {time} more second(s) before reusing the `{name}` command.",
     "errorCommend": "There was an error executing that command.",
-    "errorDJOnly": "Only users with the {DJ_ROLE} role can access this feature!")
-
+    "errorDJOnly": "Only users with the {DJ_ROLE} role can access this feature!"
   }
 }

--- a/util/EvobotUtil.js
+++ b/util/EvobotUtil.js
@@ -14,6 +14,9 @@ exports.isDJOnly = (command,member,guild) => {
   /**
    * Role checking logic
    */
+  if(!DJ_COMMANDS||DJ_COMMANDS.length==0){
+    return false;
+  }
   if(DJ_COMMANDS.indexOf(command)<0){
     return false;
   }
@@ -46,8 +49,3 @@ exports.DEFAULT_VOLUME = config ? config.DEFAULT_VOLUME: process.env.DEFAULT_VOL
 exports.LOCALE = config ? config.LOCALE : process.env.LOCALE;
 var DJ_ROLE = config ? config.DJ_ROLE : process.env.DJ_ROLE;
 var DJ_COMMANDS = exports.DJ_COMMANDS = config ? config.DJ_COMMANDS : process.env.DJ_COMMANDS;
-if(DJ_COMMANDS=="none"){
-  DJ_COMMANDS='';
-}else{
-  DJ_COMMANDS=(DJ_COMMANDS==null)?"":DJ_COMMANDS;
-}

--- a/util/EvobotUtil.js
+++ b/util/EvobotUtil.js
@@ -1,3 +1,6 @@
+const i18n = require("i18n");
+i18n.setLocale(LOCALE);
+
 exports.canModifyQueue = (member) => {
   const { channelID } = member.voice;
   const botChannel = member.guild.voice.channelID;
@@ -19,7 +22,7 @@ exports.isDJ = (member,message) => {
   };
 
   if(DJ_PERMISSION_OBJ && !message.member.roles.cache.has(DJ_PERMISSION_OBJ.id)) {
-     message.reply(`Only users with the ${DJ_ROLE} role can access this feature!`);
+     message.reply(i18n.__("common.errorDJOnly"); 
      return false;
   } 
   return true;

--- a/util/EvobotUtil.js
+++ b/util/EvobotUtil.js
@@ -14,7 +14,7 @@ exports.isDJOnly = (command,member,guild) => {
   /**
    * Role checking logic
    */
-  if(DJ_Commands.indexOf('command')<0){
+  if(DJ_Commands.indexOf(command)<0){
     return false;
   }
   if (!DJ_PERMISSION_OBJ && message) {

--- a/util/EvobotUtil.js
+++ b/util/EvobotUtil.js
@@ -48,8 +48,8 @@ exports.STAY_TIME = config ? config.STAY_TIME : process.env.STAY_TIME;
 exports.DEFAULT_VOLUME = config ? config.DEFAULT_VOLUME: process.env.DEFAULT_VOLUME;
 exports.LOCALE = config ? config.LOCALE : process.env.LOCALE;
 var DJ_ROLE = config ? config.DJ_ROLE : process.env.DJ_ROLE;
-var DJ_COMMANDS =  config ? config.DJ_COMMANDS : process.env.DJ_COMMANDS;
-if(DJ_ROLE && !DJ_COMMANDS){
-   DJ_COMMANDS = 'loop,move,pause,pruning,remove,shuffle,skip,skipto,volume,stop';
+var DJ_COMMANDS =  config ? config.DJ_COMMANDS : (process.env.DJ_COMMANDS||'').split(',');
+if(DJ_ROLE && (!DJ_COMMANDS||!DJ_COMMANDS.length)){
+   DJ_COMMANDS = 'loop,move,pause,pruning,remove,shuffle,skip,skipto,volume,stop'.split(',');
 }
 exports.DJ_COMMANDS = DJ_COMMANDS;

--- a/util/EvobotUtil.js
+++ b/util/EvobotUtil.js
@@ -46,4 +46,8 @@ exports.DEFAULT_VOLUME = config ? config.DEFAULT_VOLUME: process.env.DEFAULT_VOL
 exports.LOCALE = config ? config.LOCALE : process.env.LOCALE;
 var DJ_ROLE = config ? config.DJ_ROLE : process.env.DJ_ROLE;
 var DJ_COMMANDS = exports.DJ_COMMANDS = config ? config.DJ_COMMANDS : process.env.DJ_COMMANDS;
-DJ_COMMANDS=(DJ_COMMANDS==null)?"":DJ_COMMANDS;
+if(DJ_COMMANDS=="none"){
+  DJ_COMMANDS='';
+}else{
+  DJ_COMMANDS=(DJ_COMMANDS==null)?"":DJ_COMMANDS;
+}

--- a/util/EvobotUtil.js
+++ b/util/EvobotUtil.js
@@ -9,6 +9,22 @@ exports.canModifyQueue = (member) => {
   return true;
 };
 
+var DJ_PERMISSION_OBJ='';
+exports.isDJ = (member,message) => {
+  /**
+   * Role checking logic
+   */
+  if (!DJ_PERMISSION_OBJ) {
+    DJ_PERMISSION_OBJ = message.guild.roles.cache.find(role => role.name === DJ_ROLE)
+  };
+
+  if(DJ_PERMISSION_OBJ && !message.member.roles.cache.has(DJ_PERMISSION_OBJ.id)) {
+     message.reply(`Only users with the ${DJ_ROLE} role can access this feature!`);
+     return false;
+  } 
+  return true;
+};
+
 let config;
 
 try {
@@ -26,4 +42,4 @@ exports.PRUNING = config ? config.PRUNING : process.env.PRUNING;
 exports.STAY_TIME = config ? config.STAY_TIME : process.env.STAY_TIME;
 exports.DEFAULT_VOLUME = config ? config.DEFAULT_VOLUME: process.env.DEFAULT_VOLUME;
 exports.LOCALE = config ? config.LOCALE : process.env.LOCALE;
-exports.DJ_ROLE = config ? config.DJ_ROLE : process.env.DJ_ROLE;
+var DJ_ROLE = config ? config.DJ_ROLE : process.env.DJ_ROLE;

--- a/util/EvobotUtil.js
+++ b/util/EvobotUtil.js
@@ -28,7 +28,7 @@ exports.isDJOnly = (command,member,message) => {
   };
 
   if(DJ_PERMISSION_OBJ && !member.roles.cache.has(DJ_PERMISSION_OBJ.id)) {
-     mesage && message.reply(i18n.__("common.errorDJOnly"); 
+     mesage && message.reply(i18n.__("common.errorDJOnly")); 
      return true;
   } 
   return false;

--- a/util/EvobotUtil.js
+++ b/util/EvobotUtil.js
@@ -1,5 +1,5 @@
 const i18n = require("i18n");
-i18n.setLocale(LOCALE);
+
 
 exports.canModifyQueue = (member) => {
   const { channelID } = member.voice;
@@ -50,6 +50,7 @@ exports.MAX_PLAYLIST_SIZE = config ? config.MAX_PLAYLIST_SIZE : process.env.MAX_
 exports.PRUNING = config ? config.PRUNING : process.env.PRUNING;
 exports.STAY_TIME = config ? config.STAY_TIME : process.env.STAY_TIME;
 exports.DEFAULT_VOLUME = config ? config.DEFAULT_VOLUME: process.env.DEFAULT_VOLUME;
-exports.LOCALE = config ? config.LOCALE : process.env.LOCALE;
+var LOCALE = exports.LOCALE = config ? config.LOCALE : process.env.LOCALE;
+i18n.setLocale(LOCALE);
 var DJ_ROLE = config ? config.DJ_ROLE : process.env.DJ_ROLE;
 var DJ_Commands='loop,move,pause,pruning,remove,shuffle,skip,skipto,volume';

--- a/util/EvobotUtil.js
+++ b/util/EvobotUtil.js
@@ -46,4 +46,4 @@ exports.DEFAULT_VOLUME = config ? config.DEFAULT_VOLUME: process.env.DEFAULT_VOL
 exports.LOCALE = config ? config.LOCALE : process.env.LOCALE;
 var DJ_ROLE = config ? config.DJ_ROLE : process.env.DJ_ROLE;
 var DJ_COMMANDS = exports.DJ_COMMANDS = config ? config.DJ_COMMANDS : process.env.DJ_COMMANDS;
-DJ_COMMANDS=DJ_COMMANDS||"loop,move,pause,pruning,remove,shuffle,skip,skipto,volume,stop";
+DJ_COMMANDS=(DJ_COMMANDS==null)?"":DJ_COMMANDS;

--- a/util/EvobotUtil.js
+++ b/util/EvobotUtil.js
@@ -17,7 +17,7 @@ exports.isDJOnly = (command,member,guild) => {
   if(DJ_Commands.indexOf(command)<0){
     return false;
   }
-  if (!DJ_PERMISSION_OBJ && message) {
+  if (!DJ_PERMISSION_OBJ && guild) {
     DJ_PERMISSION_OBJ = guild.roles.cache.find(role => role.name === DJ_ROLE)
   };
 

--- a/util/EvobotUtil.js
+++ b/util/EvobotUtil.js
@@ -14,7 +14,7 @@ exports.isDJOnly = (command,member,guild) => {
   /**
    * Role checking logic
    */
-  if(DJ_Commands.indexOf(command)<0){
+  if(DJ_COMMANDS.indexOf(command)<0){
     return false;
   }
   if (!DJ_PERMISSION_OBJ && guild) {
@@ -45,4 +45,4 @@ exports.STAY_TIME = config ? config.STAY_TIME : process.env.STAY_TIME;
 exports.DEFAULT_VOLUME = config ? config.DEFAULT_VOLUME: process.env.DEFAULT_VOLUME;
 exports.LOCALE = config ? config.LOCALE : process.env.LOCALE;
 var DJ_ROLE = config ? config.DJ_ROLE : process.env.DJ_ROLE;
-var DJ_Commands='loop,move,pause,pruning,remove,shuffle,skip,skipto,volume,stop';
+var DJ_COMMANDS = exports.DJ_COMMANDS = config ? config.DJ_COMMANDS : process.env.DJ_COMMANDS;

--- a/util/EvobotUtil.js
+++ b/util/EvobotUtil.js
@@ -50,6 +50,6 @@ exports.LOCALE = config ? config.LOCALE : process.env.LOCALE;
 var DJ_ROLE = config ? config.DJ_ROLE : process.env.DJ_ROLE;
 var DJ_COMMANDS =  config ? config.DJ_COMMANDS : process.env.DJ_COMMANDS;
 if(DJ_ROLE && !DJ_COMMANDS){
-   DJ_COMMANDS = 'loop,move,pause,pruning,remove,shuffle,skip,skipto,volume,stop'
+   DJ_COMMANDS = 'loop,move,pause,pruning,remove,shuffle,skip,skipto,volume,stop';
 }
 exports.DJ_COMMANDS = DJ_COMMANDS;

--- a/util/EvobotUtil.js
+++ b/util/EvobotUtil.js
@@ -13,19 +13,25 @@ exports.canModifyQueue = (member) => {
 };
 
 var DJ_PERMISSION_OBJ='';
-exports.isDJ = (member,message) => {
+exports.isDJOnly = (command,member,message) => {
   /**
    * Role checking logic
    */
-  if (!DJ_PERMISSION_OBJ) {
+  if(!member&&message){
+    member=message.member
+  }
+  if(DJ_Commands.indexOf('command')<0){
+    return false;
+  }
+  if (!DJ_PERMISSION_OBJ && message) {
     DJ_PERMISSION_OBJ = message.guild.roles.cache.find(role => role.name === DJ_ROLE)
   };
 
-  if(DJ_PERMISSION_OBJ && !message.member.roles.cache.has(DJ_PERMISSION_OBJ.id)) {
-     message.reply(i18n.__("common.errorDJOnly"); 
-     return false;
+  if(DJ_PERMISSION_OBJ && !member.roles.cache.has(DJ_PERMISSION_OBJ.id)) {
+     mesage && message.reply(i18n.__("common.errorDJOnly"); 
+     return true;
   } 
-  return true;
+  return false;
 };
 
 let config;
@@ -46,3 +52,4 @@ exports.STAY_TIME = config ? config.STAY_TIME : process.env.STAY_TIME;
 exports.DEFAULT_VOLUME = config ? config.DEFAULT_VOLUME: process.env.DEFAULT_VOLUME;
 exports.LOCALE = config ? config.LOCALE : process.env.LOCALE;
 var DJ_ROLE = config ? config.DJ_ROLE : process.env.DJ_ROLE;
+var DJ_Commands='loop,move,pause,pruning,remove,shuffle,skip,skipto,volume';

--- a/util/EvobotUtil.js
+++ b/util/EvobotUtil.js
@@ -43,7 +43,6 @@ exports.MAX_PLAYLIST_SIZE = config ? config.MAX_PLAYLIST_SIZE : process.env.MAX_
 exports.PRUNING = config ? config.PRUNING : process.env.PRUNING;
 exports.STAY_TIME = config ? config.STAY_TIME : process.env.STAY_TIME;
 exports.DEFAULT_VOLUME = config ? config.DEFAULT_VOLUME: process.env.DEFAULT_VOLUME;
-var LOCALE = exports.LOCALE = config ? config.LOCALE : process.env.LOCALE;
-i18n.setLocale(LOCALE);
+exports.LOCALE = config ? config.LOCALE : process.env.LOCALE;
 var DJ_ROLE = config ? config.DJ_ROLE : process.env.DJ_ROLE;
 var DJ_Commands='loop,move,pause,pruning,remove,shuffle,skip,skipto,volume';

--- a/util/EvobotUtil.js
+++ b/util/EvobotUtil.js
@@ -26,3 +26,4 @@ exports.PRUNING = config ? config.PRUNING : process.env.PRUNING;
 exports.STAY_TIME = config ? config.STAY_TIME : process.env.STAY_TIME;
 exports.DEFAULT_VOLUME = config ? config.DEFAULT_VOLUME: process.env.DEFAULT_VOLUME;
 exports.LOCALE = config ? config.LOCALE : process.env.LOCALE;
+exports.DJ_ROLE = config ? config.DJ_ROLE : process.env.DJ_ROLE;

--- a/util/EvobotUtil.js
+++ b/util/EvobotUtil.js
@@ -46,3 +46,4 @@ exports.DEFAULT_VOLUME = config ? config.DEFAULT_VOLUME: process.env.DEFAULT_VOL
 exports.LOCALE = config ? config.LOCALE : process.env.LOCALE;
 var DJ_ROLE = config ? config.DJ_ROLE : process.env.DJ_ROLE;
 var DJ_COMMANDS = exports.DJ_COMMANDS = config ? config.DJ_COMMANDS : process.env.DJ_COMMANDS;
+DJ_COMMANDS=DJ_COMMANDS||"loop,move,pause,pruning,remove,shuffle,skip,skipto,volume,stop";

--- a/util/EvobotUtil.js
+++ b/util/EvobotUtil.js
@@ -1,6 +1,3 @@
-const i18n = require("i18n");
-
-
 exports.canModifyQueue = (member) => {
   const { channelID } = member.voice;
   const botChannel = member.guild.voice.channelID;
@@ -13,22 +10,18 @@ exports.canModifyQueue = (member) => {
 };
 
 var DJ_PERMISSION_OBJ='';
-exports.isDJOnly = (command,member,message) => {
+exports.isDJOnly = (command,member,guild) => {
   /**
    * Role checking logic
    */
-  if(!member&&message){
-    member=message.member
-  }
   if(DJ_Commands.indexOf('command')<0){
     return false;
   }
   if (!DJ_PERMISSION_OBJ && message) {
-    DJ_PERMISSION_OBJ = message.guild.roles.cache.find(role => role.name === DJ_ROLE)
+    DJ_PERMISSION_OBJ = guild.roles.cache.find(role => role.name === DJ_ROLE)
   };
 
   if(DJ_PERMISSION_OBJ && !member.roles.cache.has(DJ_PERMISSION_OBJ.id)) {
-     mesage && message.reply(i18n.__("common.errorDJOnly")); 
      return true;
   } 
   return false;

--- a/util/EvobotUtil.js
+++ b/util/EvobotUtil.js
@@ -45,4 +45,4 @@ exports.STAY_TIME = config ? config.STAY_TIME : process.env.STAY_TIME;
 exports.DEFAULT_VOLUME = config ? config.DEFAULT_VOLUME: process.env.DEFAULT_VOLUME;
 exports.LOCALE = config ? config.LOCALE : process.env.LOCALE;
 var DJ_ROLE = config ? config.DJ_ROLE : process.env.DJ_ROLE;
-var DJ_Commands='loop,move,pause,pruning,remove,shuffle,skip,skipto,volume';
+var DJ_Commands='loop,move,pause,pruning,remove,shuffle,skip,skipto,volume,stop';

--- a/util/EvobotUtil.js
+++ b/util/EvobotUtil.js
@@ -48,4 +48,8 @@ exports.STAY_TIME = config ? config.STAY_TIME : process.env.STAY_TIME;
 exports.DEFAULT_VOLUME = config ? config.DEFAULT_VOLUME: process.env.DEFAULT_VOLUME;
 exports.LOCALE = config ? config.LOCALE : process.env.LOCALE;
 var DJ_ROLE = config ? config.DJ_ROLE : process.env.DJ_ROLE;
-var DJ_COMMANDS = exports.DJ_COMMANDS = config ? config.DJ_COMMANDS : process.env.DJ_COMMANDS;
+var DJ_COMMANDS =  config ? config.DJ_COMMANDS : process.env.DJ_COMMANDS;
+if(DJ_ROLE && !DJ_COMMANDS){
+   DJ_COMMANDS = 'loop,move,pause,pruning,remove,shuffle,skip,skipto,volume,stop'
+}
+exports.DJ_COMMANDS = DJ_COMMANDS;


### PR DESCRIPTION
I added a comprehensive DJ role permission.
Set DJ_ROLE in config.json or in environment variable via DJ_ROLE
This will auto set 'loop,move,pause,pruning,remove,shuffle,skip,skipto,volume,stop' to only be called by a user with the DJ_ROLE pillage set within discord.
DJ_ROLE check is done on commands as well as reaction actions.
DJ_COMMAND list can be customized in config or environment variables.

Also updated the Activity status to sound nicer :-)

Thanks for your attention! Look for more contributions from me in the future