### PR TITLE
Add GitHub action to build/publish docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
     # Publish changes to the master branch.
     branches: [master]
     # Publish semver tags as releases.
-    tags: ["v*.*.*"]
+    tags: ["*.*.*"]
   pull_request:
     branches: [master]
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,58 @@
+name: Docker Build/Publish
+
+on:
+  push:
+    # Publish changes to the master branch.
+    branches: [master]
+    # Publish semver tags as releases.
+    tags: ["v*.*.*"]
+  pull_request:
+    branches: [master]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: docker.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Login against a Docker registry when not a PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ Currently available locales are:
 - Vietnamese (vi)
 - Check [Contributing](#-contributing) if you wish to help add more languages!
 
+## Docker Configuration
+
+For those who would prefer to use our [Docker container](https://hub.docker.com/repository/docker/eritislami/evobot), you may provide values from `config.json` as environment variables.
+
+```shell
+docker run -e "TOKEN=<discord-token>" -e "YOUTUBE_API_KEY=<youtube-key>" eritislami/evobot
+```
+
 ## 📝 Features & Commands
 
 > Note: The default prefix is '/'


### PR DESCRIPTION
Opening this up for discussion while I work on adding usage documentation. Fixes #894

Adds automated publishing of versioned Docker containers, pointed at [Docker Hub](https://hub.docker.com/).

**What does this mean?**
- When a new tag is created, and the tag follows [semantic versioning](https://semver.org/), the container will be published using the tag version. For example, [0.14.0](https://github.com/eritislami/evobot/releases/tag/0.14.0) would be published as eritislami/evobot:v0.14.0
- When a change is pushed to the master branch, GitHub actions will automatically build and deploy these updates to the `master` version.

As a way to ensure PRs don't break the Docker build process, this will also build (but not deploy) the Dockerfile when a PR is opened.

**Required setup**
The below items are REQUIRED for this process to work correctly:

- The `eritislami` account must be created (looks like this was done while I was working on this PR. Thank you!)
- In Docker Hub, the `evobot` repository must be created.
- An Access Token must be created to allow GitHub to deploy to Docker Hub
  - Account Settings > Security > New Access Token
  - Name it whatever you want. I used "Evobot Deployment Token"
  - Give it Read and Write permissions
  - Keep the token in a safe place
- In GitHub, Secrets must be created
	- In the evobot repositroy, navigate to:
	- Settings > Secrets > New Repository Secret
	- Create the following secrets:
		- DOCKERHUB_USERNAME 
		  - This is your username when logging into Docker Hub (mine is drewburr)
		- DOCKERHUB_TOKEN
		  - This is that token we just generated

After the above is done, this deployment will work! 
This process was tested using a [forked repo](https://github.com/drewburr/evobot) and my own [Docker Hub repo](https://hub.docker.com/repository/docker/drewburr/evobot).