### PR TITLE
Change API to keyless API

### DIFF
--- a/commands/play.js
+++ b/commands/play.js
@@ -2,6 +2,7 @@ const i18n = require("../util/i18n");
 const { play } = require("../include/play");
 const ytdl = require("ytdl-core");
 const YouTubeAPI = require("simple-youtube-api");
+const YTKeyless = require("youtube-search-without-api-key");
 const scdl = require("soundcloud-downloader").default;
 const https = require("https");
 const { YOUTUBE_API_KEY, SOUNDCLOUD_CLIENT_ID, DEFAULT_VOLUME } = require("../util/Util");
@@ -104,7 +105,7 @@ module.exports = {
       }
     } else {
       try {
-        const results = await youtube.searchVideos(search, 1, { part: "id" });
+        const results = await YTKeyless.search(search);
 
         if (!results.length) {
           message.reply(i18n.__("play.songNotFound")).catch(console.error);

--- a/commands/search.js
+++ b/commands/search.js
@@ -1,7 +1,5 @@
 const { MessageEmbed } = require("discord.js");
-const YouTubeAPI = require("simple-youtube-api");
-const { YOUTUBE_API_KEY } = require("../util/Util");
-const youtube = new YouTubeAPI(YOUTUBE_API_KEY);
+const YTKeyless = require("youtube-search-without-api-key");
 const i18n = require("../util/i18n");
 
 module.exports = {
@@ -24,8 +22,9 @@ module.exports = {
       .setColor("#F8AA2A");
 
     try {
-      const results = await youtube.searchVideos(search, 10);
-      results.map((video, index) => resultsEmbed.addField(video.shortURL, `${index + 1}. ${video.title}`));
+      const results = await YTKeyless.search(search);
+	  results.length -= 10;
+      results.map((video, index) => resultsEmbed.addField("https://youtu.be/"+video.id.videoId, `${index + 1}. ${video.title}`));
 
       let resultsMessage = await message.channel.send(resultsEmbed);
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "soundcloud-downloader": "^0.2.3",
     "string-progressbar": "^1.0.4",
     "ytdl-core": "^4.9.1",
-    "ytdl-core-discord": "^1.3.1"
+    "ytdl-core-discord": "^1.3.1",
+	  "youtube-search-without-api-key": "^1.0.6"
   },
   "scripts": {
     "start": "node index.js",


### PR DESCRIPTION
This impacts commands that utilize the YouTube API for simple lookups such as (search, play) where the YouTube API can be replaced with a package that utilizes a "scraper" to collect the video ID, URL, title, etc. 

This eliminates the quota cost for these requests and essentially makes the bot have "infinite" uses. I tested this bot on my own discord server hosted on a dedicated server and so far it seems to work great. 

The only problem is that I haven't figured out how to make this "new" API work with playlists as it doesn't seem to be designed for them, and as such, will likely keep having to use the "regular" YouTube API with a key for playlist functions.