### PR TITLE
fix(play): Incorrect reading flags in process.env

### DIFF
--- a/include/play.js
+++ b/include/play.js
@@ -15,7 +15,7 @@ module.exports = {
       config = null;
     }
 
-    const PRUNING = config ? config.PRUNING : process.env.PRUNING;
+    const PRUNING = config ? config.PRUNING : process.env.PRUNING === 'true';
 
     const queue = message.client.queue.get(message.guild.id);
 


### PR DESCRIPTION
https://nodejs.org/api/process.html#process_process_env

> Assigning a property on process.env will implicitly convert the value to a string.