### PR TITLE
refactor(search): refactor 'awaitMessages' call

### DIFF
--- a/commands/search.js
+++ b/commands/search.js
@@ -35,25 +35,31 @@ module.exports = {
       }
 
       message.channel.activeCollector = true;
-      const response = await message.channel.awaitMessages(filter, { max: 1, time: 30000, errors: ["time"] });
-      const reply = response.first().content;
+      message.channel.awaitMessages(filter, { max: 1, time: 30000, errors: ["time"] })
+        .then(async (collected) => {
+          const reply = collected.first().content
 
-      if (reply.includes(",")) {
-        let songs = reply.split(",").map((str) => str.trim());
+          if (reply.includes(",")) {
+            let songs = reply.split(",").map((str) => str.trim());
 
-        for (let song of songs) {
-          await message.client.commands
-            .get("play")
-            .execute(message, [resultsEmbed.fields[parseInt(song) - 1].name]);
-        }
-      } else {
-        const choice = resultsEmbed.fields[parseInt(response.first()) - 1].name;
-        message.client.commands.get("play").execute(message, [choice]);
-      }
+            for (let song of songs) {
+              await message.client.commands
+                .get("play")
+                .execute(message, [resultsEmbed.fields[parseInt(song) - 1].name]);
+            }
+          } else {
+            const choice = resultsEmbed.fields[parseInt(reply) - 1].name;
+            message.client.commands.get("play").execute(message, [choice]);
+          }
 
-      message.channel.activeCollector = false;
-      resultsMessage.delete().catch(console.error);
-      response.first().delete().catch(console.error);
+          message.channel.activeCollector = false;
+          resultsMessage.delete().catch(console.error);
+          collected.first().delete().catch(console.error);
+        })
+        .catch(() => {
+          message.channel.activeCollector = false;
+          resultsMessage.edit(`${message.author}, Unfortunately, I didn't receive your response **within 30 seconds**`);
+        });
     } catch (error) {
       console.error(error);
       message.channel.activeCollector = false;


### PR DESCRIPTION
This commit refactores `awaitMessages` call to prevent getting Discord API Errors **("Cannot send an
empty message")** on 30-second timeout

Before this change, script would go to the catch block after a 30-second timeout, which meant that message with the search results got "stuck" in the chat and user didn't receive any explanatory messages *(Only `console.log` showed a message about `Discord API Error`)*. Now, search results are replaced by a custom timeout message, which is more understandable to the user

*Also, according to Discord.js [documentation](https://discord.js.org/#/docs/main/stable/class/TextChannel?scrollTo=awaitMessages) and [examples of use](https://discordjs.guide/popular-topics/collectors.html#await-messages), `message.channel.awaitMessage` doesn't need an `await`*

*Proof or work:*
- Before timeout: 
![image](https://user-images.githubusercontent.com/36604233/134935626-2fc18dc1-f791-4dee-ab53-56baafeb73c7.png)

- After timeout: 
![image](https://user-images.githubusercontent.com/36604233/134935653-c23c53fa-a34d-45e9-a29e-8a3b5ffcfbf7.png)
