### PR TITLE
Update regex to only accept numbers 1-10

### DIFF
--- a/commands/search.js
+++ b/commands/search.js
@@ -30,7 +30,7 @@ module.exports = {
       let resultsMessage = await message.channel.send(resultsEmbed);
 
       function filter(msg) {
-        const pattern = /^[0-9]{1,2}(\s*,\s*[0-9]{1,2})*$/;
+        const pattern = /^[1-9][0]?(\s*,\s*[1-9][0]?)*$/;
         return pattern.test(msg.content);
       }
 


### PR DESCRIPTION
The existing regex allows numbers 0-99 as a response to the `search` command. Any values outside of 1-10 will cause the following exception:

```
TypeError: Cannot read property 'name' of undefined
    at Object.execute (/home/drewburr/evobot/commands/search.js:50:76)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

And the following message in Discord

```
@drewburr, Cannot read property 'name' of undefined
```

Fixes #973.