### PR TITLE
Fix reading undefined when stop command is called in loop mode

### DIFF
--- a/include/play.js
+++ b/include/play.js
@@ -64,7 +64,7 @@ module.exports = {
 
         queue.connection.removeAllListeners("disconnect");
 
-        if (queue.loop) {
+        if (queue.loop && queue.songs.length > 0) {
           // if loop is on, push the song back at the end of the queue
           // so it can repeat endlessly
           let lastSong = queue.songs.shift();


### PR DESCRIPTION
Thank you for merging PR #1056.
I found a bug that caused stop commands would fail in loop mode, so I fixed it.