### PR TITLE
Fix for making the importer work on Windows.

### DIFF
--- a/utils/importCommands.js
+++ b/utils/importCommands.js
@@ -1,6 +1,6 @@
 import { readdirSync } from "fs";
 import { dirname, join } from "path";
-import { fileURLToPath } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
@@ -8,7 +8,7 @@ export async function importCommands(client) {
   const commandFiles = readdirSync(join(__dirname, "..", "commands")).filter((file) => file.endsWith(".js"));
 
   for (const file of commandFiles) {
-    const command = await import(join(__dirname, "..", "commands", `${file}`));
+    const command = await import(join(pathToFileURL(__dirname).href, "..", "commands", `${file}`));
     client.commands.set(command.default.name, command.default);
   }
 }


### PR DESCRIPTION
* fixes the importer not working on Windows cause of the ESM loader errors of the path not being a file URL.
* tested & working. should be able to close #1143.