### PR TITLE
fix(search): avoid APIError when search query didn't lead to any results

### DIFF
--- a/commands/search.ts
+++ b/commands/search.ts
@@ -33,11 +33,14 @@ export default {
       results = await youtube.search(search, { limit: 10, type: "video" });
     } catch (error: any) {
       console.error(error);
-
       interaction.editReply({ content: i18n.__("common.errorCommand") }).catch(console.error);
+      return;
     }
 
-    if (!results) return;
+    if (!results || !results[0]) {
+      interaction.editReply({ content: i18n.__("search.noResults") })
+      return;
+    }
 
     const options = results!.map((video) => {
       return {

--- a/locales/en.json
+++ b/locales/en.json
@@ -125,7 +125,8 @@
     "errorNotChannel": "You need to join a voice channel first!",
     "resultEmbedTitle": "**Reply with the song number you want to play**",
     "resultEmbedDesc": "Results for: {search}",
-    "optionQuery": "Search query"
+    "optionQuery": "Search query",
+    "noResults": "No results for query, please try something else"
   },
   "shuffle": {
     "description": "Shuffle queue",


### PR DESCRIPTION
fix #1441

Not sure if localization should be used for this as I've never worked with it, but other locales with the missing property do fallback to English so thought it should be fine - let me know